### PR TITLE
Fix double bracket condition parsing

### DIFF
--- a/create_env.py
+++ b/create_env.py
@@ -58,7 +58,7 @@ class MetaFileParser:
                 dbl_bracket_start = line.find('[[')
                 dbl_bracket_end = line.find(']]')
                 if dbl_bracket_start != -1:
-                    condition = line[dbl_bracket_start + 1:]
+                    condition = line[dbl_bracket_start + 2:]
                     if do_print:
                         do_print_ = self._eval_condition(condition)
                     else:


### PR DESCRIPTION
Given a line to parse like this:
```python
example_line = "[[val == var"
double_bracket_start = example_line.find('[[')
```

The current implementation is this:
```python
condition = example_line[double_bracket_start + 1:]
# condition: '[val == var'
```

But it should be this:
```python
condition = example_line[double_bracket_start + 2:]
# condition: 'val == var'
```